### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @domenkozar @lucperkins @fricklerhandwerk @infinisil @yukiisbored


### PR DESCRIPTION
I'm not quite sure how we want to distribute responsibility in the nix.dev templates, so I'm suggesting a global permissions approach. I suspect these templates won't change much over time and won't be too complex, so this seems like a reasonable model.
